### PR TITLE
Use logging instead of a print statement when loading.

### DIFF
--- a/config_with_yaml/config.py
+++ b/config_with_yaml/config.py
@@ -2,9 +2,12 @@
 
 __author__ = 'aitormf'
 
-import sys, os
+import logging
+import os
 import yaml
 from .properties import Properties
+
+LOGGER = logging.getLogger(__name__)
 
 
 def findConfigFile(filename):
@@ -45,7 +48,7 @@ def load(filename):
     filepath = findConfigFile(filename)
     prop= None
     if (filepath):
-        print ('loading Config file %s' %(filepath))
+        LOGGER.info("Loading Config file %s", filepath)
 
         with open(filepath, 'r') as stream:
             cfg=yaml.load(stream, Loader=yaml.FullLoader)


### PR DESCRIPTION
Use logging instead of a print statement. This gives the user freedom to configure log messages depending on the application rather than always printing.